### PR TITLE
Update RNImgToBase64Module.java

### DIFF
--- a/android/src/main/java/fr/snapp/imagebase64/RNImgToBase64Module.java
+++ b/android/src/main/java/fr/snapp/imagebase64/RNImgToBase64Module.java
@@ -2,12 +2,16 @@
 package fr.snapp.imagebase64;
 
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.provider.MediaStore;
 import android.util.Base64;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -30,17 +34,39 @@ public class RNImgToBase64Module extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void getBase64String(String uri, Promise promise) {
+    Bitmap image = null;
     try {
-      Bitmap image = MediaStore.Images.Media.getBitmap(reactContext.getContentResolver(), Uri.parse(uri));
+      if (uri.contains("http")) {
+        image = getBitmapFromURL(uri);
+      } else {
+        image = MediaStore.Images.Media.getBitmap(reactContext.getContentResolver(), Uri.parse(uri));
+      }
       if (image == null) {
         promise.reject("Error", "Failed to decode Bitmap, uri: " + uri);
       } else {
         promise.resolve(bitmapToBase64(image));
       }
     } catch (Error e) {
+      promise.reject("Error", "Failed to decode Bitmap: " + e);
       e.printStackTrace();
     } catch (Exception e) {
+      promise.reject("Error", "Exception: " + e);
       e.printStackTrace();
+    }
+  }
+
+  public Bitmap getBitmapFromURL(String src) {
+    try {
+      URL url = new URL(src);
+      HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+      connection.setDoInput(true);
+      connection.connect();
+      InputStream input = connection.getInputStream();
+      Bitmap myBitmap = BitmapFactory.decodeStream(input);
+      return myBitmap;
+    } catch (IOException e) {
+      e.printStackTrace();
+      return null;
     }
   }
 


### PR DESCRIPTION
fixed a bug when pass a remote uri rather than local uri in getBase64String method.