### PR TITLE
Fix - ERROR | attributes: Missing required attribute `homepage` in po…

### DIFF
--- a/ios/RNImgToBase64.podspec
+++ b/ios/RNImgToBase64.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                     Convert img to base64
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/Snapp-FidMe/react-native-img-to-base64"
   s.license      = "MIT"
   s.author       = { "author" => "contact@snapp.fr" }
   s.platform     = :ios, "7.0"


### PR DESCRIPTION
Fix the error while getting pod install for RN version 0.60+

`[!] The RNImgToBase64 pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute homepage`